### PR TITLE
profile作成時にデフォルト画像をアタッチする処理を削除

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,8 +1,4 @@
-require 'open-uri'
-
 class Profile < ApplicationRecord
-  before_create :set_default_avatar
-
   belongs_to :user
 
   has_one_attached :avatar
@@ -12,22 +8,6 @@ class Profile < ApplicationRecord
   validates :avatar, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 1..5.megabytes }
 
   def avatar_thumbnail
-    avatar.variant(resize_to_limit: [1200, 400]).processed
-  end
-
-  private
-
-  def set_default_avatar
-    return if avatar.attached?
-
-    avatar.attach(
-      io: URI.open(default_avatar_url),
-      filename: 'default_avatar.png',
-      content_type: 'image/png'
-    )
-  end
-
-  def default_avatar_url
-    ENV['DEFAULT_AVATAR_URL']
+    avatar.variant(resize_to_fit: [400, 400]).processed
   end
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -11,11 +11,11 @@
 
       <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
         
-        <%= f.label :name, class: "sm:text-4xl text-3xl mb-4 font-medium text-gray-900" %>
+        <%= f.label :name, class: "text-gray-900" %>
         <%= f.text_field :name, autofocus: true, autocomplete: "name",
-                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
+                class: "w-full px-3 py-2 mb-4 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
 
-        <%= f.label :description, class: "mb-4 leading-relaxed" %>
+        <%= f.label :description, class: "leading-relaxed" %>
         <%= f.text_area :description, autofocus: true, autocomplete: "description",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
         <!-- グループリスト始まり -->
@@ -36,7 +36,7 @@
         </li>
         <%end%>
         <!-- グループリスト終わり -->
-        <div class="items-start">
+        <div class="items-start mt-4">
           <%= f.submit "再登録", class: "btn btn-success"%>
         </div>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,12 @@
 <section class="text-gray-600">
   <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-start">
     <div class="flex justify-center items-start lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
-      <%= image_tag(@profile.avatar)%>
+      <% if @profile.avatar.attached? %>
+        <%= image_tag(@profile.avatar_thumbnail)%>
+      <%else%>
+        <%= image_tag("/default_avatar.png")%>
+      <%end%>
+
     </div>
     <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
       <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900"><%= "Name : #{@user.profile.name}" %> </h1>


### PR DESCRIPTION
User作成と同時にprofileを作成し、その段階でbeforecreateコールバックを使用してavatarにデフォルトアバターをアタッチしていたがその必要はなく、アバターが登録されていればそのアバターを、登録されていなければ`/public`に保存した`default_avatar.png`をprofileのshow画面で表示されるように変更
合わせてリサイズする画像のサイズを変更、`resize_to_limit`から`resize_to_fit`に変更