### PR TITLE
招待リンク表示ページ変更、request.statusをcompletedに更新するメソッドを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,9 @@ class ApplicationController < ActionController::Base
         group.update(invite_token: nil)
         flash[:notice] = "すでに#{group.name}グループに参加しています"
       end
+    else
+      session[:group_id] = nil
+      group.update(invite_token: nil)
     end
 
     super
@@ -42,7 +45,6 @@ class ApplicationController < ActionController::Base
     else
       session[:group_id] = nil
       group.update(invite_token: nil)
-      flash[:notice] = "#{group.name}グループに追加されました"
     end
 
     super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,9 +26,6 @@ class ApplicationController < ActionController::Base
         group.update(invite_token: nil)
         flash[:notice] = "すでに#{group.name}グループに参加しています"
       end
-    else
-      session[:group_id] = nil
-      group.update(invite_token: nil)
     end
 
     super

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -1,7 +1,7 @@
 class ApprovalsController < ApplicationController
-  before_action :authenticate_user!, only: %i[admit cancel_admit]
-  before_action :set_group, only: %i[admit cancel_admit]
-  before_action :set_request, only: %i[admit cancel_admit]
+  before_action :authenticate_user!, only: %i[admit cancel_admit task_completed]
+  before_action :set_group, only: %i[admit cancel_admit task_completed]
+  before_action :set_request, only: %i[admit cancel_admit task_completed]
 
   # 承認(authorizersのレコードの数と承認の数が一致したとき、request.statusをpossibleに更新)
   def admit
@@ -26,6 +26,11 @@ class ApprovalsController < ApplicationController
     else
       redirect_to group_request_path(@group, @request), notice: '承認取り消しに失敗しました'
     end
+  end
+
+  def task_completed
+    @request.completed! if @request.possible?
+    redirect_to group_requests_path, notice: 'タスクを完了しました'
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,7 +10,11 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
 
-  def show; end
+  def show
+    return unless @group.invite_token.present?
+
+    @invite_link = group_invite_link_url(@group, invite_token: @group.invite_token)
+  end
 
   def create
     @group = Group.new(group_params)

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,20 +1,9 @@
 class InvitesController < ApplicationController
-  before_action :authenticate_user!, only: %i[new]
-  def new
-    @group = Group.find(params[:group_id])
-
-    @invite_link = if @group.invite_token.present?
-                     group_invite_link_url(invite_token: @group.invite_token)
-                   else
-                     ''
-                   end
-  end
-
   def generate_token
     group = Group.find(params[:group_id])
     invite_token = Devise.friendly_token
-    group.update(invite_token:)
-    redirect_to groups_path
+    group.update(invite_token: invite_token )
+    redirect_to group_path(group)
   end
 
   def process_invite_link
@@ -26,7 +15,7 @@ class InvitesController < ApplicationController
       session[:group_id] = nil
       @group.update(invite_token: nil)
 
-      redirect_to root_path, notice: "#{@group.name}に追加されました"
+      redirect_to root_path, notice: "#{@group.name}グループに追加されました"
     else
       redirect_to user_session_path
     end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,7 +2,7 @@ class Request < ApplicationRecord
   validates :take, :status, presence: true
   validates :image, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 1..5.megabytes }
 
-  enum status: { unauthorized: 0, authorized: 1, possible: 2 }
+  enum status: { unauthorized: 0, authorized: 1, possible: 2, completed: 3 }
 
   has_one_attached :image
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,6 +36,10 @@
               <%= f.submit t("defaults.register"), class: "w-full px-3 py-4 text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>
             </div>
 
+            <div class="flex mb-6">
+              <%= link_to "LINEアカウントで登録", user_line_omniauth_authorize_path, method: :post, class: "px-3 py-4 w-full text-white text-center bg-green-500 rounded-md" %>
+            </div>
+
             <% end %>
 
             <div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,39 +1,31 @@
-<div class="flex items-center min-h-screen bg-white dark:bg-gray-900">
-    <div class="container mx-auto">
-        <div class="max-w-md mx-auto my-10">
-            <div class="text-center">
-                <h1 class="my-3 text-3xl font-semibold text-gray-700 dark:text-gray-200"><%= t("defaults.login")%></h1>
-            </div>
-            <%= form_with model:@user, url: user_session_path, method: :post do |f| %>
-              <div class="mb-6">
-                <%= f.label :email, class: "block mb-2 text-sm text-gray-600 dark:text-gray-400" %>
-                <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "test@exemple.com",
-                  class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
-              </div>
-              <div class="mb-6">
-                <%= f.label :password, class: "block mb-2 text-sm text-gray-600 dark:text-gray-400" %>
-                <%= f.password_field :password, autofocus: true, autocomplete: "current-password",
-                  class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
-              </div>
-              <div class="mb-6">
-                <%= f.submit t("defaults.login"), class: "w-full px-3 py-4 text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>
-              </div>
-              <div class="mb-6">
-                <%= link_to "LINEでログイン", user_line_omniauth_authorize_path, method: :post, class: "w-full px-3 py-4 text-white bg-green-500 rounded-md focus:bg-green-600 focus:outline-none" %>
-              </div>
-              <% if devise_mapping.rememberable? %>
-                <div class="field text-sm text-gray-400 focus:outline-none focus:text-indigo-500 hover:text-indigo-500 dark:hover:text-indigo-300">
-                  <%= f.check_box :remember_me %>
-                  <%= f.label :remember_me %>
-                </div>
-              <% end %>
-            <% end %>
-            <div>
-              <%= link_to t(".forget_password"), "#", class: "text-sm text-gray-400 focus:outline-none focus:text-indigo-500 hover:text-indigo-500 dark:hover:text-indigo-300"%>
-            </div>
-            <div>
-              <%= link_to t(".new_user_register"), new_user_registration_path, class: "text-sm text-gray-400 focus:outline-none focus:text-indigo-500 hover:text-indigo-500 dark:hover:text-indigo-300"%>
-            </div>
+<div class="flex items-center my-10 bg-white">
+  <div class="container mx-auto">
+    <div class="max-w-md mx-auto">
+      <div class="text-center">
+        <h1 class="my-3 text-3xl font-semibold text-gray-700 dark:text-gray-200"><%= t("defaults.login")%></h1>
+      </div>
+      <%= form_with model:@user, url: user_session_path, method: :post do |f| %>
+        <div class="mb-6">
+          <%= f.label :email, class: "mb-2 text-sm text-gray-600" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "test@exemple.com", class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
         </div>
+        <div class="mb-6">
+          <%= f.label :password, class: "mb-2 text-sm text-gray-600" %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "current-password", class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
+        </div>
+        <div class="mb-6">
+          <%= f.submit t("defaults.login"), class: "w-full px-3 py-4 text-white bg-indigo-500 rounded-md bg-indigo-600 focus:outline-none" %>
+        </div>
+      <% end %>
+      <div class="flex mb-6">
+        <%= link_to "LINEでログイン", user_line_omniauth_authorize_path, method: :post, class: "px-3 py-4 w-full text-white text-center bg-green-500 rounded-md" %>
+      </div>
+      <div>
+        <%= link_to t(".forget_password"), "#", class: "text-sm text-gray-400 focus:outline-none focus:text-indigo-500 hover:text-indigo-500"%>
+      </div>
+      <div>
+        <%= link_to t(".new_user_register"), new_user_registration_path, class: "text-sm text-gray-400 focus:outline-none focus:text-indigo-500 hover:text-indigo-500"%>
+      </div>
     </div>
+  </div>
 </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -18,14 +18,10 @@
             <h1 class="text-xl font-semibold leading-none tracking-tighter text-blue-600 lg:mb-0 hover:text-neutral-600"><%= link_to group.name, group_requests_path(group) %></h1>
           </div>
           <p class="mx-auto text-base leading-relaxed text-gray-500"><%= group.description %></p>
-          <% if group.invite_token %>
-            <p class="mx-auto text-base leading-relaxed text-gray-500"><%= group.invite_token %></p>
-          <%end%>
 
           <div class="flex gap-4 mt-4">
             <div><%= link_to "詳細", group_path(group), class: "inline-flex items-center mt-4 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
             <div><%= link_to "編集", edit_group_path(group), class: "inline-flex items-center mt-4 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
-            <div><%= button_to "招待リンク作成", group_generate_token_path(group), method: :post, class: "inline-flex items-center mt-4 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
           </div>
 
         </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -21,7 +21,6 @@
 
           <div class="flex gap-4 mt-4">
             <div><%= link_to "詳細", group_path(group), class: "inline-flex items-center mt-4 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
-            <div><%= link_to "編集", edit_group_path(group), class: "inline-flex items-center mt-4 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
           </div>
 
         </div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,6 +1,5 @@
 <div class="text-center">
     <h1 class="my-3 text-3xl font-semibold text-gray-700 dark:text-gray-200">Group Create</h1>
-    <p class="text-gray-500 dark:text-gray-400">グループ作成</p>
 </div>
 
 <%= render partial: "form", locals: { group: @group, form_url: groups_path }%>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -4,11 +4,16 @@
       <h1 class="mb-4 text-center text-2xl font-semibold text-indigo-500 md:mb-6 lg:text-3xl"><%= @group.name %></h1>
 
       <p class="mx-auto max-w-screen-md text-center text-gray-500 md:text-lg"><%= @group.description %></p>
+      <% if @invite_link.present? %>
+        <p class="mx-auto max-w-screen-md text-center text-gray-500 md:text-lg">下のURLをコピーして招待したい人に送ってください</p>
+        <p class="mx-auto max-w-screen-md text-center text-gray-500 md:text-lg"><%= @invite_link %></p>
+      <%end%>
+
 
     </div>
     <div class="flex justify-end space-x-4">
       <div><%= link_to "編集", edit_group_path, class: "btn btn-warning" %></div>
-      <div><%= link_to "招待リンク生成ページ", group_invite_new_path(@group), class: "btn btn-warning" %></div>
+      <div><%= button_to "招待リンク生成", group_generate_token_path(@group), method: :post, class: "btn btn-warning" %></div>
       <div><%= button_to "削除", group_path, class: "btn btn-error", method: :delete %></div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
       <%= render "shared/header" %>
     </header>
 
-    <div class="pt-20">
+    <div class="mt-20">
       <% flash.each do |key, message| %>
       <div class="alert alert-<%= key %>">
         <%= message %>
@@ -24,7 +24,7 @@
       <% end %>
     </div>
 
-    <div class="flex flex-row bg-white pb-20 min-h-screen overflow-y-auto">
+    <div class="flex flex-row bg-white mb-14 min-h-screen overflow-y-auto">
       <%  if user_signed_in? %>
         <%= render "shared/sidebar"%>
       <%end%>

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -1,10 +1,8 @@
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
     <!-- text - start -->
-    <div class="mb-10 md:mb-16">
-      <h2 class="mb-4 text-center text-2xl font-bold text-gray-800 md:mb-6 lg:text-3xl">Requests Edit</h2>
-
-      <p class="mx-auto max-w-screen-md text-center text-gray-500 md:text-lg">ここにリクエスト書いてみよか〜</p>
+    <div class="mb-5">
+      <h2 class="mb-4 text-center text-3xl font-bold text-gray-800">Requests Edit</h2>
     </div>
     <!-- text - end -->
 

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-screen-2xl px-4">
     <!-- text - start -->
     <div class="mb-5">
-      <h2 class="mb-4 text-center text-2xl font-bold text-gray-800 md:mb-6 lg:text-3xl">Requests New</h2>
+      <h2 class="mb-4 text-center text-3xl font-bold text-gray-800">Requests New</h2>
     </div>
     <!-- text - end -->
 

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -10,17 +10,14 @@
       </div>
     </div>
     
-    <div class="flex flex-row gap-5 mb-4">
+    <% if @request.image.present?%>
+    <div class="flex flex-row gap-2 mb-4">
       <!-- File Attachment -->
-
-      <% if @request.image.present?%>
-        <div class="mr-5">
-          <div class="border rounded-lg p-2">
-              <%= image_tag @request.image_thumbnail %>
-          </div>
+      <div>
+        <div class="border rounded-lg p-2">
+            <%= image_tag @request.image_thumbnail %>
         </div>
-      <% end %>
-      <!-- Request Deteal -->
+      </div>
       <div class="w-full">
         <div>
           <p>日時</p>
@@ -33,70 +30,135 @@
           </div>
 
           <p>コメント</p>
-          <div class="mb-2 border overflow-y-auto rounded-lg h-44 p-2">
+          <div class="border overflow-y-auto rounded-lg h-[200px] p-2">
+            <%= @request.comment%>
+          </div>
+        </div>
+      </div>
+    </div>
+    <% else %>
+    <div class="flex flex-row gap-2 mb-4">
+      <!-- File Attachment -->
+      <div class="w-full">
+        <div>
+          <p>日時</p>
+          <div class="mb-2 border rounded-lg p-2">
+            <% if @request.execution_date.present?%>
+              <%= l @request.execution_date, format: :japan %>
+            <% else %>
+              <p>要相談</p>
+            <% end %>
+          </div>
+
+          <p>コメント</p>
+          <div class="border overflow-y-auto rounded-lg h-[200px] p-2">
             <%= @request.comment%>
           </div>
         </div>
       </div>
     </div>
 
+    <% end %>
 
-    <div class="flex gap-2">
-      <div class="w-1/2 mb-2 border bg-red-100 rounded-lg p-2">
-        <ul class="list-none">
-            <% @uncompleted_gives.each do |give| %>
-              <li>
-                <% if give.deadline.present? %>
-                  <div class="flex justify-between gap-2">
-                    <%= "#{give.content} : #{l give.deadline}" %>
-                    <div class="flex gap-2">
-                      <%= button_to "完了", update_status_completed_group_request_gife_path(@group, @request, give), method: :post, class: "btn  btn-info btn-xs" %>
+
+    <% if @request.authorized? || @request.possible?%>
+      <div class="flex gap-2">
+        <div class="w-1/2 mb-2 border bg-red-100 rounded-lg p-2 items-center h-28">
+          <ul class="list-none">
+              <% @uncompleted_gives.each do |give| %>
+                <li>
+                  <% if give.deadline.present? %>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : #{l give.deadline}" %>
+                      <div class="flex gap-2">
+                        <%= button_to "完了", update_status_completed_group_request_gife_path(@group, @request, give), method: :post, class: "btn  btn-info btn-xs" %>
+                      </div>
                     </div>
-                  </div>
-                <%else%>
-                  <div class="flex justify-between gap-2">
-                    <%= "#{give.content} : 日時未定" %>
-                    <div class="flex gap-2">
-                      <%= button_to "完了", update_status_completed_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-info btn-xs" %>
+                  <%else%>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : 日時未定" %>
+                      <div class="flex gap-2">
+                        <%= button_to "完了", update_status_completed_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-info btn-xs" %>
+                      </div>
                     </div>
-                  </div>
-                <%end%>
-              </li>
-            <%end%>
-        </ul>
+                  <%end%>
+                </li>
+              <%end%>
+          </ul>
+        </div>
+
+        <div class=" w-1/2 mb-2 border bg-blue-100 rounded-lg p-2 items-center h-28">
+          <ul class="list-none">
+              <% @completed_gives.each do |give| %>
+                <li>
+                  <% if give.deadline.present? %>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : #{l give.deadline}" %>
+                      <div class="flex gap-2">
+                        <%= button_to "取消", update_status_uncompleted_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-error btn-xs" %>
+                      </div>
+                    </div>
+                  <%else%>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : 日時未定" %>
+                      <div class="flex gap-2">
+                        <%= button_to "取消", update_status_uncompleted_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-error btn-xs" %>
+                      </div>
+                    </div>
+                  <%end%>
+                </li>
+              <%end%>
+          </ul>
+        </div>
       </div>
 
-      <div class=" w-1/2 mb-2 border bg-blue-100 rounded-lg p-2">
-        <ul class="list-none">
-            <% @completed_gives.each do |give| %>
-              <li>
-                <% if give.deadline.present? %>
-                  <div class="flex justify-between gap-2">
-                    <%= "#{give.content} : #{l give.deadline}" %>
-                    <div class="flex gap-2">
-                      <%= button_to "取消", update_status_uncompleted_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-error btn-xs" %>
+    <%else%>
+    
+      <div class="flex flex-row gap-2">
+        <div class="flex w-1/2 mb-2 border bg-red-100 rounded-lg p-2 items-center h-28">
+          <ul class="list-none">
+              <% @uncompleted_gives.each do |give| %>
+                <li>
+                  <% if give.deadline.present? %>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : #{l give.deadline}" %>
                     </div>
-                  </div>
-                <%else%>
-                  <div class="flex justify-between gap-2">
-                    <%= "#{give.content} : 日時未定" %>
-                    <div class="flex gap-2">
-                      <%= button_to "取消", update_status_uncompleted_group_request_gife_path(@group, @request, give), method: :post, class: "btn btn-error btn-xs" %>
+                  <%else%>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : 日時未定" %>
                     </div>
-                  </div>
-                <%end%>
-              </li>
-            <%end%>
-        </ul>
+                  <%end%>
+                </li>
+              <%end%>
+          </ul>
+        </div>
+
+        <div class="flex w-1/2 mb-2 border bg-blue-100 rounded-lg p-2 items-center h-28">
+          <ul class="list-none">
+              <% @completed_gives.each do |give| %>
+                <li>
+                  <% if give.deadline.present? %>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : #{l give.deadline}" %>
+                    </div>
+                  <%else%>
+                    <div class="flex justify-between gap-2">
+                      <%= "#{give.content} : 日時未定" %>
+                    </div>
+                  <%end%>
+                </li>
+              <%end%>
+          </ul>
+        </div>
       </div>
+    <%end%>
 
-    </div>
 
-    <!-- User and Search -->
+    <!-- menber -->
       <div>
         メンバー
       </div>
-      <ul class="flex mb-4 list-none list-inside">
+      <ul class="flex mb-4 list-none list-inside border rounded-lg p-6">
         <% @request.authorizers.each do |authorizer| %>
           <% request_user = @request.request_users.find_by(user_id: authorizer.id) %>
           <li class="mr-2">
@@ -166,6 +228,12 @@
         </div>
       <% end %>
 
+      <% if @request.own?(current_user) && @request.possible? %>
+        <div class="btn btn-success">
+          <%= button_to "完了", group_request_task_completed_path(@group, @request), method: :post %>
+        </div>
+      <% end %>
+
       <% if @request.authorizers_check(current_user) && @subject_authorizer.unauthorized? %>
       <div class="btn btn-primary">
         <%= button_to "承認", group_request_admit_path(@group, @request), method: :post %>
@@ -178,5 +246,5 @@
       </div>
       <% end %>
     </div>
-
   </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap items-baseline justify-center ml-80">
+<div class="flex flex-wrap mx-auto items-baseline justify-center">
   <div class="mt-5 mb-5 text-sm font-light text-gray-500">
     <%= link_to "お問い合わせ", "#", class: "mr-4"%>
     <%= link_to "利用規約", "#", class: "mx-4"%>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div class="flex bg-white rounded-lg">
-  <div class="flex flex-col my-5 px-8">
-    <ul class="overflow-y-auto bg-blue-50 w-52 h-5/6">
+  <div class="flex flex-col">
+    <ul class="overflow-y-auto bg-blue-50 w-52 h-full">
       <li class="menu-title text-black mt-3 mb-4">グループ</li>
         <% current_user.groups.each do |group| %>
           <div class="break-words w-44 ml-4 mb-4 text-gray-500 hover:text-blue-500">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,9 +28,12 @@ ja:
       index:
         unauthorized: 未承認
         authorized: 承認済
-        possible: 完了
+        possible: タスク実行可能
+        completed: タスク完了
       show:
         unauthorized: 未承認
         authorized: 承認済
-        possible: 完了
+        possible: タスク実行可能
+        completed: タスク完了
+
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :requests do
       post 'admit', to: 'approvals#admit'
       post 'cancel_admit', to: 'approvals#cancel_admit'
+      post 'task_completed', to: 'approvals#task_completed'
       resources :gives, only: [] do
         member do
           post 'update_status_completed', to: 'gives#update_status_completed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   resource :profile, only: %i[show edit update]
 
   resources :groups do
-    get 'new', to: 'invites#new', as: 'invite_new'
     post 'generate_token', to: 'invites#generate_token'
     get 'process_invite_link/:invite_token', to: 'invites#process_invite_link', as: 'invite_link'
     resources :requests do


### PR DESCRIPTION
group.indexから詳細に行けば生成ページに行かなくとも招待リンクを作成できるように修正
58b61b9ecae7ba24f4cbe415ab7de6f6e48cfbcc

requestのstatusがpossibleになり全てのgiveを完了した場合、statusをcompletedに更新できるメソッドを追加し、showページにボタンを追加した
e911041047b1d2012f86e5f3c946eec695054f4f
8c04c8ac5c389eb095083783e110cdfd97ab1f85