### PR TITLE
lineプロフィール画像がprofile.avatarにアタッチされる機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'line-bot-api'
 gem 'omniauth-line'
 gem 'omniauth-rails_csrf_protection'
 gem 'rails-i18n'
+gem 'mimemagic'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mimemagic (0.4.3)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
@@ -401,6 +404,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   line-bot-api
+  mimemagic
   omniauth-line
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -21,6 +21,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
 
       @user.set_values(@omniauth)
+      @user.set_profile_avatar(@omniauth.info.image) if @omniauth.info.image.present?
       sign_in(:user, @user)
     end
     flash[:notice] = 'ログインしました'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
+require 'mimemagic'
+require 'open-uri'
+
 class User < ApplicationRecord
   validates :email, presence: true
   validates :password, presence: true, length: { minimum: 7 }
@@ -31,8 +34,30 @@ class User < ApplicationRecord
     access_token = credentials['refresh_token']
     access_secret = credentials['secret']
     credentials = credentials.to_json
+  end
+
+  def set_profile_name(url)
     profile = self.profile || build_profile
     profile.name = info['name']
+    profile.save!
+  end
+
+  def set_profile_avatar(url)
+    profile = self.profile || build_profile
+    downloaded_avatar = URI.open(url)
+
+    mimetype = MimeMagic.by_magic(downloaded_avatar)
+    ext = case mimetype.type
+          when "image/jpeg"
+            "jpg"
+          when "image/png"
+            "png"
+          else
+            "unknown"
+          end
+
+    filename = "user_#{user.id}_avatar.#{exe}"
+    profile.avatar.attach(io: downloaded_avatar, filename: filename, content_type: mime_type.type)
     profile.save!
   end
 


### PR DESCRIPTION
LINEからプロフィール画像をダウンロードするが拡張子が不明のためmimemagicを使用して拡張子を特定
特定した拡張子を画像のファイル名拡張子に使用