### PR TITLE
タイポ修正 既存のアバターがある場合、LINEアイコンで上書きしないように修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -21,7 +21,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
 
       @user.set_values(@omniauth)
-      @user.set_profile_avatar(@omniauth.info.image) if @omniauth.info.image.present?
+      @user.set_profile_name(@omniauth['info']['name']) if @omniauth['info']['name'].present?
+      @user.set_profile_avatar(@omniauth['info']['image']) if @omniauth['info']['image'].present?
       sign_in(:user, @user)
     end
     flash[:notice] = 'ログインしました'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,29 +36,31 @@ class User < ApplicationRecord
     credentials = credentials.to_json
   end
 
-  def set_profile_name(url)
+  def set_profile_name(name)
     profile = self.profile || build_profile
-    profile.name = info['name']
+    profile.name = name
     profile.save!
   end
 
   def set_profile_avatar(url)
     profile = self.profile || build_profile
-    downloaded_avatar = URI.open(url)
 
-    mimetype = MimeMagic.by_magic(downloaded_avatar)
-    ext = case mimetype.type
-          when "image/jpeg"
-            "jpg"
-          when "image/png"
-            "png"
-          else
-            "unknown"
-          end
+    unless profile.avatar.attached?
+      downloaded_avatar = URI.open(url)
+      mimetype = MimeMagic.by_magic(downloaded_avatar)
+      ext = case mimetype.type
+            when "image/jpeg"
+              "jpg"
+            when "image/png"
+              "png"
+            else
+              "unknown"
+            end
 
-    filename = "user_#{self.id}_avatar.#{ext}"
-    profile.avatar.attach(io: downloaded_avatar, filename: filename, content_type: mime_type.type)
-    profile.save!
+      filename = "user_#{self.id}_avatar.#{ext}"
+      profile.avatar.attach(io: downloaded_avatar, filename: filename, content_type: mimetype.type)
+      profile.save!
+    end
   end
 
   def set_values_by_raw_info(raw_info)


### PR DESCRIPTION
Userのクラスメソッドに`set_profile_name(name)`と`set_profile_avatar(url)`を追加
`set_profile_name(name)`はもともと`set_values`に含めていたprofileのnameを保存するメソッドから分けて記述した
`set_profile_avatar(url)`はログインするたびにLINEアイコンがprofile.avatarにアタッチされてしまっていたため、既存のavatarがアタッチされている場合はLINEアイコンをアバターに設定しないように修正

close #108 