### PR TITLE
request投稿時の画像プレビュー機能実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,16 +2,12 @@
 import { Application } from "stimulus";
 
 // 個々のStimulusコントローラーをインポート
-import AvatarPreviewController from "./controllers/avatar_preview_controller";
+import ImagePreviewController from "./controllers/image_preview_controller";
 
 // Stimulusのアプリケーションインスタンスを作成
 const application = Application.start();
 
 // コントローラーをStimulusアプリケーションに登録
-application.register("avatar-preview", AvatarPreviewController);
-
-// 他のコントローラーがあれば、以下のように追加
-// import AnotherController from "./controllers/another_controller";
-// application.register("another", AnotherController);
+application.register("image-preview", ImagePreviewController);
 
 // これ以降に、他のJavaScriptやライブラリのセットアップを行う

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -12,6 +12,8 @@ export default class extends Controller {
     const preview = this.previewTarget
     // input.filesはユーザーが選択したファイルのリスト
     const files = input.files
+    const width = this.data.get('width')
+
 
     // files[0]は最初のファイルを参照する
     if (files && files[0]) {
@@ -21,7 +23,7 @@ export default class extends Controller {
       // reader.onloadは「ファイルの読み込みが完了したら次に何をするか」という指示をするもの
       reader.onload = (e) => {
         // 発火する内容を定義
-        preview.innerHTML = `<img src="${e.target.result}" style="max-width: 300px;">`
+        preview.innerHTML = `<img src="${e.target.result}" style="max-width: ${width}px;">`;
       }
       reader.readAsDataURL(files[0])
     }

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -6,9 +6,9 @@
         <% if @profile.avatar.attached? %>
             <%= image_tag(@profile.avatar_thumbnail)%>
         <% end %>
-        <div data-controller="avatar-preview">
-          <%= f.file_field :avatar, data: { "avatar-preview-target": "input", "action": "change->avatar-preview#previewImage"}, class: "object-cover object-center rounded" %>
-          <div data-avatar-preview-target="preview" class="mt-5"></div>
+        <div data-controller="image-preview" data-image-preview-width="300">
+          <%= f.file_field :avatar, data: { "image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "object-cover object-center rounded" %>
+          <div data-image-preview-target="preview" class="mt-5"></div>
         </div>
       </div>
 

--- a/app/views/requests/shared/_form.html.erb
+++ b/app/views/requests/shared/_form.html.erb
@@ -10,9 +10,15 @@
     <%= f.label :execution_date, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
     <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300" %>
   </div>
-  <div class="sm:col-span-2">
-    <%= f.label :image, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
-    <%= f.file_field :image, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition" %>
+  
+  <div data-controller="image-preview" data-image-preview-width="200" class="sm:col-span-2 grid grid-cols-2 gap-4">
+    <!-- 左側: 画像アップロードフィールド -->
+    <div>
+      <%= f.label :image, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
+      <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition" %>
+    </div>
+    <!-- 右側: 画像プレビュー表示 -->
+    <div data-image-preview-target="preview" class="sm:col-span-1"></div>
   </div>
 
   <div class="sm:col-span-2 border-b-2"></div>


### PR DESCRIPTION
先に作成していた`avatar_preview_controller.js`を他のビューページでも使用できるよう`image_preview_controller.js`に修正した
内容としては表示するプレビュー画像のサイズを変更したかったため
### 追加
`const width = this.data.get('width')`
### 修正
`preview.innerHTML = `<img src="${e.target.result}" style="max-width: ${width}px;">`;`
とした
799d95a696ee7b74e82aacc235c7480a39ae5c18

requestのnewページでも画像が投稿できるため、プレビュー機能を追加した
プレビュー画像のサイズは`max-width: "300"`とした
04617ae1a6b5d52bafd500d3dca691bac611d86b

close #101 