### PR TITLE
誤ったマイグレーションファイルを削除

### DIFF
--- a/db/migrate/20240109054237_drop_messages.rb
+++ b/db/migrate/20240109054237_drop_messages.rb
@@ -1,9 +1,0 @@
-class DropMessages < ActiveRecord::Migration[7.0]  # バージョンは適宜調整してください
-  def up
-    drop_table :messages
-  end
-
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
-end


### PR DESCRIPTION
以前誤って作成したMessageモデルのマイグレーションファイルが残っておりそれをそのままherokuにプッシュしていたため、前回デプロイしたマイグレーションファイルがうまくマイグレーションできなかった
マイグレーションを行うため誤ったマイグレーションファイルを削除し、再度デプロイする