### PR TITLE
actioncableのアダプタをpostgresqlに変更

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,8 @@
 development:
-  adapter: async
+  adapter: postgresql
 
 test:
-  adapter: test
+  adapter: postgresql
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: kimochi3_production
+  adapter: postgresql


### PR DESCRIPTION
本番環境のactioncableのアダプタを`redis`から`posgresql`に変更
develop,test環境もposgreにした