### PR TITLE
リアルタイムチャット機能修正

### DIFF
--- a/app/channels/chat_channel.rb
+++ b/app/channels/chat_channel.rb
@@ -10,12 +10,11 @@ class ChatChannel < ApplicationCable::Channel
     message = request.messages.create(content: data['message'], user: user)
 
     # 保存されたメッセージをブロードキャスト
-    ChatChannel.broadcast_to(request, message: render_message(message))
-  end
-
-  private
-
-  def render_message(message)
-    ApplicationController.renderer.render(partial: 'messages/message', locals: { message: message, current_user: current_user})
+    ChatChannel.broadcast_to(request, {
+      user_id: user.id,
+      user_name: user.profile.name,
+      created_at: message.formatted_created_at,
+      content: message.content
+                             })
   end
 end

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -10,10 +10,23 @@ export default class extends Controller {
       { channel: "ChatChannel", request_id: this.requestIdValue },
       {
         received: data => {
+          // 送信者が現在のユーザーかどうかを判断
+          const isCurrentUser = data.user_id === this.currentUserIdValue;
+          const messageClass = isCurrentUser ? 'chat chat-start' : 'chat chat-end';
+        
           // ブロードキャストされたメッセージを表示
-          this.messagesTarget.innerHTML += data.message
+          this.messagesTarget.innerHTML += `
+            <div class="${messageClass}">
+              <div class="chat-header">
+                ${data.user_name}
+                <time class="text-xs opacity-50">${data.created_at}</time>
+              </div>
+              <div class="chat-bubble">${data.content}</div>
+            </div>
+          `;
+        
           this.scrollToBottom();
-          console.log("hello")
+
         }
       }
     );

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,8 @@
 class Message < ApplicationRecord
   belongs_to :request
   belongs_to :user
+
+  def formatted_created_at
+    created_at.strftime("%m/%d %H:%M")
+  end
 end


### PR DESCRIPTION
リアルタイムチャットについてrecieveメソッドによるHTMLの表示がうまくいっていなかったため
直接HTMLを生成し、リアルタイムに表示させることにした
aa917b0d28a83f827661b52e45a07c783e3e7c00

chat_channel,rbでlメソッドが使用できなかったため、messageクラスメソッドを作成して時刻のフォーマットを定義した
f5b250db74f77f39d2e487469da793f90732a0f2

close #40 