### PR TITLE
特定のGroup.invite_tokenカラムの値を生成された30分後に削除する機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'omniauth-line'
 gem 'omniauth-rails_csrf_protection'
 gem 'rails-i18n'
 gem 'mimemagic'
+gem 'delayed_job_active_record'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,11 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    delayed_job (4.1.11)
+      activesupport (>= 3.0, < 8.0)
+    delayed_job_active_record (4.1.8)
+      activerecord (>= 3.0, < 8.0)
+      delayed_job (>= 3.0, < 5)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -393,6 +398,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  delayed_job_active_record
   devise
   devise-i18n
   devise-i18n-views

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec rails jobs:work

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -3,6 +3,9 @@ class InvitesController < ApplicationController
     group = Group.find(params[:group_id])
     invite_token = Devise.friendly_token
     group.update(invite_token: invite_token )
+
+    InviteTokenRemovalJob.set(wait: 30.minutes).perform_later(group.id)
+
     redirect_to group_path(group)
   end
 

--- a/app/jobs/invite_token_removal_job.rb
+++ b/app/jobs/invite_token_removal_job.rb
@@ -1,0 +1,8 @@
+class InviteTokenRemovalJob < ApplicationJob
+  queue_as :default
+
+  def perform(group_id)
+    group = Group.find_by(id: group_id)
+    group&.update(invite_token: nil)
+  end
+end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module Kimochi3
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}").to_s]
     config.assets.initialize_on_precompile = false
     config.active_storage.variant_processor = :vips
+    config.active_job.queue_adapter = :delayed_job
 
     config.generators do |g|
       g.asset false

--- a/db/migrate/20240116040443_create_delayed_jobs.rb
+++ b/db/migrate/20240116040443_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_09_055251) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_16_040443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,21 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_09_055251) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "gives", force: :cascade do |t|


### PR DESCRIPTION
delayed_jobを利用して招待機能操作時作られるGroup.invite_tokenが、生成されて30分経過しても使用されなかった(誰も招待されなかった)場合、トークンを削除する機能を追加