### PR TITLE
invite_token_removal_job.rbで実装した機能を修正

### DIFF
--- a/app/jobs/invite_token_removal_job.rb
+++ b/app/jobs/invite_token_removal_job.rb
@@ -3,6 +3,6 @@ class InviteTokenRemovalJob < ApplicationJob
 
   def perform(group_id)
     group = Group.find_by(id: group_id)
-    group&.update(invite_token: nil)
+    group.update(invite_token: nil) if group.invite_token.present?
   end
 end


### PR DESCRIPTION
`group&.update(invite_token: nil)`では`group`の有無により実行の判別するが実際は`group.invite_token`の有無により処理を行うかの判別を行いたかったため修正

close #132 