### PR TITLE
requestのindex画面に投稿者を表示する実装,  statusがcompletedになったrequest一覧ページの作成

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -4,11 +4,16 @@ class RequestsController < ApplicationController
   before_action :set_group, only: %i[index new show edit update destroy]
 
   def index
-    all_requests = Request.where(group_id: params[:group_id]).order(updated_at: :desc)
+    all_requests = Request.includes(user: :profile).where(group_id: params[:group_id]).order(updated_at: :desc)
     @draft_requests = paginated_draft_requests(all_requests, params[:draft_page])
     @unauthorized_requests = paginated_unauthorized_requests(all_requests, params[:unauthorized_page])
     @authorized_requests = paginated_authorized_requests(all_requests, params[:authorized_page])
     @possible_requests = paginated_possible_requests(all_requests, params[:possible_page])
+  end
+
+  def completed_requests
+    all_requests = Request.includes(user: :profile).where(group_id: params[:group_id]).order(updated_at: :desc)
+    @completed_requests = paginated_completed_requests(all_requests, params[:completed_page])
   end
 
   def show
@@ -94,7 +99,7 @@ class RequestsController < ApplicationController
   end
 
   def paginated_draft_requests(requests, page)
-    filtered_requests = requests.select { |request| request.status == "draft" && request.own?(current_user)}
+    filtered_requests = requests.select { |request| request.status == "draft" && request.own?(current_user) }
     Kaminari.paginate_array(filtered_requests).page(page)
   end
 
@@ -110,6 +115,11 @@ class RequestsController < ApplicationController
 
   def paginated_possible_requests(requests, page)
     filtered_requests = requests.select { |request| (request.status == "possible") }
+    Kaminari.paginate_array(filtered_requests).page(page)
+  end
+
+  def paginated_completed_requests(requests, page)
+    filtered_requests = requests.select { |request| (request.status == "completed") }
     Kaminari.paginate_array(filtered_requests).page(page)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,7 @@ import ImagePreviewController from "./controllers/image_preview_controller";
 import ChatController from "./controllers/chat_controller";
 import LogoutController from "./controllers/logout_controller";
 import ClipboardController from "./controllers/clipboard_controller";
+import LinkController from "./controllers/link_controller";
 
 
 // Stimulusのアプリケーションインスタンスを作成
@@ -16,6 +17,7 @@ application.register("image-preview", ImagePreviewController);
 application.register("chat", ChatController);
 application.register("logout", LogoutController);
 application.register("clipboard", ClipboardController);
+application.register("link", LinkController);
 
 
 // これ以降に、他のJavaScriptやライブラリのセットアップを行う

--- a/app/javascript/controllers/link_controller.js
+++ b/app/javascript/controllers/link_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  
+  go(event) {
+    event.preventDefault();
+
+    const url = event.currentTarget.dataset.url;
+
+    if (url) {
+      window.location.href = url;
+    }
+  }
+}

--- a/app/views/requests/completed_requests.html.erb
+++ b/app/views/requests/completed_requests.html.erb
@@ -1,0 +1,28 @@
+<div class="bg-white my-10 px-8 text-gray-500 font-sans ">
+  <div class="mx-auto max-w-screen-xl">
+    <div class="overflow-x-auto">
+      <table class="table">
+        <!-- head -->
+        <thead class="text-center">
+          <tr>
+            <th>No.</th>
+            <th><%= t("groups.requests.completed_requests.take")%></th>
+            <th><%= t("groups.requests.completed_requests.create_user_name")%></th>
+            <th><%= t("groups.requests.completed_requests.created_at")%></th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- row 1 -->
+          <% @completed_requests.each_with_index do |request, index| %>
+          <tr data-controller="link" data-action="click->link#go" data-url="<%= group_request_path(params[:group_id], request) %>" class="hover text-center" >
+            <td><%= index + 1%></td>
+            <td><%= request.take %></td>
+            <td><%= request.user.profile.name %></td>
+            <td><%= l request.created_at, format: :japan%></td>
+          </tr>
+          <%end%>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -10,8 +10,9 @@
       <div class="flex h-96"><%= render "/requests/shared/requests_list", title: t("groups.requests.index.possible"), requests: @possible_requests, paginate_param: "possile_page" %></div>
     </div>
 
-    <div class="flex justify-center items-end mt-12 font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600">
+    <div class="flex justify-center items-end mt-12 gap-4 font-semibold hover:text-neutral-600">
       <%= link_to "新規リクエスト作成", new_group_request_path(@group), class: "w-auto px-3 py-4 text-white text-sm bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>
+      <%= link_to "完了リクエスト確認", completed_group_requests_path(@group), class: "w-auto px-3 py-4 text-white text-sm bg-purple-500 rounded-md focus:bg-purple-600 focus:outline-none" %>
     </div>
   </div>
 </div>

--- a/app/views/requests/shared/_request_item.html.erb
+++ b/app/views/requests/shared/_request_item.html.erb
@@ -2,10 +2,14 @@
   <div class="text-sm font-semibold text-gray-800 dark:text-white">
     <%= link_to request.take, group_request_path(request.group, request) %>
   </div>
-  <div class="mt-1 text-xs text-gray-800">
-    <%= "許可数: #{request.request_users.where(approval_status: 1).count}/#{request.request_users.count}" %>
-    <% if request.execution_date.present? %>
-      <%= "#{l request.execution_date, format: :short}" %>
-    <% end %>
+  <div class="flex flex-col mt-1 text-xs text-gray-800">
+    <div><%= request.user.profile.name%>
+      <% if request.execution_date.present? %>
+        <%= "#{l request.execution_date, format: :short}" %>
+      <% end %>
+    </div>
+    <div>
+      <%= "許可数: #{request.request_users.where(approval_status: 1).count}/#{request.request_users.count}" %>
+    </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -43,5 +43,10 @@ ja:
         authorized: 承認済
         possible: タスク実行可能
         completed: タスク完了
+      completed_requests:
+        take: 概要
+        create_user_name: 投稿者
+        created_at: 作成日時
+        link: リンク
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     get 'process_invite_link/:invite_token', to: 'invites#process_invite_link', as: 'invite_link'
     delete 'secession', to: 'groups#secession'
     resources :requests do
+      get 'completed_requests', on: :collection, to: 'requests#completed_requests', as: 'completed'
       post 'admit', to: 'approvals#admit'
       post 'cancel_admit', to: 'approvals#cancel_admit'
       post 'task_completed', to: 'approvals#task_completed'


### PR DESCRIPTION
request.indexのビューページで作成したユーザー名が表示されるように修正
close #150
898705a31416c8f789f65795e35b0200baadb71e

そのグループ内で`status`が`completed`となった`request`を一覧で確認できるような新たな`completed_requests.htmk.erb`を作成
close #102
close #151
9c94ac04a2c5f58a95bd174e18c1d834e3685408

上記で作成したテーブルで、内容確認のためにrequest.showページに遷移する方法として、一覧のどこかをクリックすればページ遷移する機能を実装
142895d04cb0d28bf03e25bea46bb336fa2d89cc