### PR TITLE
groupsテーブルにuser_idをreferences型で追加

### DIFF
--- a/db/migrate/20240130074439_add_user_id_to_groups.rb
+++ b/db/migrate/20240130074439_add_user_id_to_groups.rb
@@ -1,0 +1,5 @@
+class AddUserIdToGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :groups, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_16_040443) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_074439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,6 +83,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_16_040443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "invite_token"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_groups_on_user_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -152,6 +154,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_16_040443) do
   add_foreign_key "gives", "requests"
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "groups", "users"
   add_foreign_key "messages", "requests"
   add_foreign_key "messages", "users"
   add_foreign_key "profiles", "users"


### PR DESCRIPTION
groupオブジェクトを作成したuserを明示化するためにgroupsテーブルにuser_idカラムをreferences型で追加
現在`null: true`に設定しているが、現在本番環境に既存のGroupオブジェクトが存在するため、既存GroupオブジェクトにはコンソールでGroupsオブジェクトにuser_idを追加後、`null: false`にするマイグレーションを再度読み込む予定
674adb7c490f65ebe98752273bf0dc73139fd0f4