### PR TITLE
groupsテーブルのuser_idのnull: trueの設定をfalseに変更

### DIFF
--- a/db/migrate/20240130101117_change_user_id_not_null_in_groups.rb
+++ b/db/migrate/20240130101117_change_user_id_not_null_in_groups.rb
@@ -1,0 +1,7 @@
+class ChangeUserIdNotNullInGroups < ActiveRecord::Migration[7.0]
+  def change
+    def change
+      change_column_null :groups, :user_id, false
+    end
+  end
+end


### PR DESCRIPTION
#167 で追加した`groupsテーブル`の`user_id`カラムの`null: true`の設定を`null: false`に変更
なお本番環境において存在したGroupオブジェクトにはコンソールでuser_idを直接付与した
6c6288710eff38ad930d123d099208f066117061