### PR TITLE
GroupモデルとUserモデルのアソシエーション設定　Group作成時にcurrent_user.idを関連づけるように修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,6 +20,7 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
+    @group.owner = current_user
     if @group.save
       @group.users << current_user
       redirect_to groups_path

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,4 +7,8 @@ class Group < ApplicationRecord
   has_many :requests, dependent: :destroy
 
   belongs_to :owner, class_name: 'User', foreign_key: 'user_id', inverse_of: :owned_groups
+
+  def owner?(user)
+    user_id == user.id
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,4 +5,6 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
 
   has_many :requests, dependent: :destroy
+
+  belongs_to :owner, class_name: 'User', foreign_key: 'user_id', inverse_of: :owned_groups
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
 
   has_many :messages, dependent: :destroy
 
+  has_many :owned_groups, class_name: 'Group', inverse_of: :owner, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -24,7 +24,9 @@
     <div class="flex justify-center space-x-4 mt-10">
       <div><%= button_to "編集", edit_group_path,  method: :get, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %></div>
       <div><%= button_to "招待リンク生成", group_generate_token_path(@group), method: :post, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-xs sm:text-base text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %></div>
-      <div><%= button_to "脱退", group_secession_path(@group), class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
+      <% unless @group.owner?(current_user) %>
+        <div><%= button_to "脱退", group_secession_path(@group), class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
+      <% end %>
       <div><%= button_to "削除", group_path, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
     </div>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_074439) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_30_101117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Groupモデルには以下のようにアソシエーション設定を行った
`inverse_of`オプションを使い双方向関連付けを行った
`belongs_to :owner, class_name: 'User', foreign_key: 'user_id', inverse_of: :owned_groups`

Userモデルには以下のようにアソシエーション設定を行った
`inverse_of`オプションを使い双方向関連付けを行った
`has_many :owned_groups, class_name: 'Group', inverse_of: :owner, dependent: :destroy`
395048af21f977163f33ee20fc07fdfc610936e5

Groupのクラスメソッドに`owner?`を追加し、groupのshowページでボタンの表示、非表示の判定を行なっている
58143d4cf98574a280cf70b925281ac80a8990c1

`groups_controller.rb`の`createアクション`に`@group.owner = current_user`を追加し、グループ作成時、current_user.idが@group.user_idになるように実装
fbf183c533eac3deac40e23360847b2da9a2d0df