### PR TITLE
groupの削除ボタンの表示・非表示判定、招待リンクボタンの背景色変更、groupのindexページの「詳細　完成リクエスト一覧」の文字間隔を修正、google analytics導入

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -19,7 +19,7 @@
           </div>
           <h1 class="text-lg sm:text-xl font-semibold leading-none tracking-tighter text-gray-500 sm:mb-0 hover:text-neutral-800"><%= link_to group.name, group_requests_path(group) %></h1>
         </div>
-        <div class="flex gap-4">
+        <div class="flex gap-7">
           <div><%= link_to "詳細", group_path(group), class: "inline-flex text-sm sm:text-base items-center sm:font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
           <div><%= link_to "完了リクエスト一覧", completed_group_requests_path(group), class: "inline-flex text-sm sm:text-base items-center sm:font-semibold text-blue-600 lg:mb-0 hover:text-neutral-600" %></div>
         </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -23,7 +23,7 @@
 
     <div class="flex justify-center space-x-4 mt-10">
       <div><%= button_to "編集", edit_group_path,  method: :get, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %></div>
-      <div><%= button_to "招待リンク生成", group_generate_token_path(@group), method: :post, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-xs sm:text-base text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %></div>
+      <div><%= button_to "招待リンク生成", group_generate_token_path(@group), method: :post, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-xs sm:text-base text-white bg-teal-400 rounded-md focus:bg-teal-500 focus:outline-none" %></div>
       <% unless @group.owner?(current_user) %>
         <div><%= button_to "脱退", group_secession_path(@group), class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
       <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -27,7 +27,9 @@
       <% unless @group.owner?(current_user) %>
         <div><%= button_to "脱退", group_secession_path(@group), class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
       <% end %>
-      <div><%= button_to "削除", group_path, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
+      <% if @group.owner?(current_user)%>
+        <div><%= button_to "削除", group_path, class: "mx-auto sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-white bg-rose-400 rounded-md focus:bg-rose-500 focus:outline-none", method: :delete %></div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,15 @@
 <html>
   <head>
     <title>Kimochi3</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JBECTS8XHY"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', 'G-JBECTS8XHY');
+    </script>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
Groupのクラスメソッド`owner?`を使用してグループを削除するボタンが表示されるのは`Group.user_id == current_user.id`のみの場合とした
088fe8ab88bf5e4bf728434502cf8ea7ffbdb2b6

招待リンク作成ボタンの背景色を変更した
[![Image from Gyazo](https://i.gyazo.com/b8135586146d1c1d625c361ee6061828.png)](https://gyazo.com/b8135586146d1c1d625c361ee6061828)
e166f5a254a3ef418591c5ca81b2d4434ba92bba

groupのindexページ表示される`詳細　完了リクエスト一覧の文字間隔を広げた`
[![Image from Gyazo](https://i.gyazo.com/9d583e3b4d29b71145d46e9454a80fdb.png)](https://gyazo.com/9d583e3b4d29b71145d46e9454a80fdb)

google analytics導入
41ed6ba03bf55d44d848d48d64c2782ad67b3a9d
