### PR TITLE
過去にログインしたことがあるか、ないかでページの遷移先を変更する機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,12 @@ class ApplicationController < ActionController::Base
     end
 
     super
+
+    if resource.sign_in_count == 1
+      root_path
+    else
+      group_requests_path(resource.groups.first)
+    end
   end
 
   def after_sign_up_path_for(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[line]
+         :trackable, :omniauthable, omniauth_providers: %i[line]
 
   def social_profile(provider)
     social_profiles.select { |sp| sp.provider == provider.to_s }.first

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,9 @@
           <%= link_to "所属グループ一覧", groups_path, class: "px-6 py-6 text-sm border-b-2 border-transparent leading-[22px] #{ header_group_index_class } hover:text-blue-500" %>
         </li>
         <li>
+          <%= link_to "使い方", root_path, class: "px-6 py-6 text-sm border-b-2 border-transparent leading-[22px] #{ header_group_index_class } hover:text-blue-500" %>
+        </li>
+        <li>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: {controller: "logout" }, class: "px-2 sm:px-6 py-0 sm:py-2 text-xs sm:text-sm border-b-2 border-transparent leading-[22px] text-gray-500 hover:text-blue-500" %>
         </li>
         <li>
@@ -37,6 +40,9 @@
             </li>
             <li>
               <%= link_to "所属グループ一覧", groups_path, class: "px-2 sm:px-6 py-0 sm:py-2 text-xs sm:text-sm border-b-2 border-transparent leading-[22px] #{ header_group_index_class } hover:text-blue-500" %>
+            </li>
+            <li>
+              <%= link_to "使い方", root_path, class: "px-2 sm:px-6 py-0 sm:py-2 text-xs sm:text-sm border-b-2 border-transparent leading-[22px] text-gray-500 hover:text-blue-500" %>
             </li>
             <li>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: {controller: "logout" }, class: "px-2 sm:px-6 py-0 sm:py-2 text-xs sm:text-sm border-b-2 border-transparent leading-[22px] text-gray-500 hover:text-blue-500" %>

--- a/db/migrate/20240201235841_add_trackable_to_users.rb
+++ b/db/migrate/20240201235841_add_trackable_to_users.rb
@@ -1,0 +1,11 @@
+class AddTrackableToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users do |t|
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_101117) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_235841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -145,6 +145,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_101117) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
deviseの`traclable`モジュールを使用するために`usersテーブル`に以下のようにカラムを追加
```ruby
t.integer :sign_in_count, default: 0, null: false
t.datetime :current_sign_in_at
t.datetime :last_sign_in_at
t.string :current_sign_in_ip
t.string :last_sign_in_ip
```
429f6ae0b127564eb2a0419e03a5638cb9c8b37e

`Userモデル`に`trackable`モジュールを追加
6728d3c29dd8464ee447b367c62ed3df5154f128

ヘッダーに`使い方`というリンクを追加(現在`root_path`)のままだがroute.rbを調整してもいいかもしれない
30b34e1e939bc42a879896a26f71c2d3636b0b58

deviseのログイン後ページ遷移先を変更するために`application_controller.rb`の`after_sign_in_path_for(resource)`を修正
```ruby
    if resource.sign_in_count == 1
      root_path
    else
      group_requests_path(resource.groups.first)
    end
```
先ほど追加した`sign_in_count`の数が`1`の時（初回ログイン時）にページ遷移先を`root_path`に変更
すでにログインしたことのあるユーザーは`group_requests_path`に遷移するように変更
2a0e1a88dbcf263473463e751f0091f69823c11a

close #180 