### PR TITLE
basic_actionアクション内のsign_inメソッドを修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -23,7 +23,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.set_values(@omniauth)
       @user.set_profile_name(@omniauth['info']['name']) if @omniauth['info']['name'].present?
       @user.set_profile_avatar(@omniauth['info']['image']) if @omniauth['info']['image'].present?
-      sign_in(:user, @user)
+      sign_in_and_redirect @user
     end
     flash[:notice] = 'ログインしました'
     redirect_to root_path


### PR DESCRIPTION
LINEログイン時にページ遷移先が判別されておらず、本番環境ログを確認すると`  def after_sign_in_path_for(resource)
`メソッドが使用されていなかったので`omniauth_callbacks_controller.rb`の`baacic_action`メソッド内で使われていた
`sign_in(:user, @user)`を`sign_in_and_redirect @user`に変更した