### PR TITLE
ログイン後、2度ページ遷移しているエラーを修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -24,9 +24,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.set_profile_name(@omniauth['info']['name']) if @omniauth['info']['name'].present?
       @user.set_profile_avatar(@omniauth['info']['image']) if @omniauth['info']['image'].present?
       sign_in_and_redirect @user
+    else
+      flash[:notice] = '認証に失敗しました'
+      new_user_session_path
     end
-    flash[:notice] = 'ログインしました'
-    redirect_to root_path
   end
 
   def fake_email(uid, provider)


### PR DESCRIPTION
#194 実装した結果エラーが発生しログを確認すると
```
AbstractController::DoubleRenderError (Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return".):
```
とあったので`basic_action`メソッド内にある`redirect_to root_path`が原因と仮定し`redirect_to root_path`が実行されないように修正