### PR TITLE
ログイン後の画面遷移先をprofile showページに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
     if resource.sign_in_count == 1
       root_path
     else
-      group_requests_path(resource.groups.first)
+      profile_path(resource)
     end
   end
 


### PR DESCRIPTION
ログインした際に初めての場合は`使い方`を書いたページへ遷移、2度目以降は`group_requests_path`に遷移させていたが、初めてのログイン後にグループもリクエストも作成していない場合エラーが発生すると思われるので、2度目以降のログインの場合は`profile_path`に遷移するように修正