### PR TITLE
テキストカラーの統一、フォームの背景色の統一、フォームラベルをfont-boldに統一、フォームをfocusしたときの挙動を統一、ヘッダー「使い方」のアクティブ化

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,14 @@ module ApplicationHelper
     end
   end
 
+  def header_top_class
+    if params[:controller] == 'top_page' && params[:action] == 'top'
+      'text-blue-500'
+    else
+      'text-gray-500'
+    end
+  end
+
   def status_bg_color(status)
     case status
     when 'unauthorized'

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,12 +4,12 @@
 
             <%= form_with model: group, url: form_url, local: true do |f| %>
             <div class="mb-6">
-              <%= f.label :name, class: "block mb-2 text-base text-gray-500" %>
+              <%= f.label :name, class: "block mb-2 text-base font-bold text-gray-500" %>
               <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "らんてっくぐるーぷ",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6">
-              <%= f.label :description, class: "block mb-2 text-base text-gray-500" %>
+              <%= f.label :description, class: "block mb-2 text-base font-bold text-gray-500" %>
               <%= f.text_area :description, autofocus: true, placeholder: "グループの説明",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,12 +4,12 @@
 
             <%= form_with model: group, url: form_url, local: true do |f| %>
             <div class="mb-6">
-              <%= f.label :name, class: "block mb-2 text-sm text-gray-500" %>
+              <%= f.label :name, class: "block mb-2 text-base text-gray-500" %>
               <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "らんてっくぐるーぷ",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6">
-              <%= f.label :description, class: "block mb-2 text-sm text-gray-500" %>
+              <%= f.label :description, class: "block mb-2 text-base text-gray-500" %>
               <%= f.text_area :description, autofocus: true, placeholder: "グループの説明",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="flex items-center bg-white dark:bg-gray-900">
+<div class="flex items-center bg-white">
     <div class="container mx-auto">
         <div class="max-w-md mx-2 sm:mx-auto my-10">
 
@@ -6,12 +6,12 @@
             <div class="mb-6">
               <%= f.label :name, class: "block mb-2 text-sm text-gray-800" %>
               <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "らんてっくぐるーぷ",
-                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
+                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6">
               <%= f.label :description, class: "block mb-2 text-sm text-gray-800" %>
               <%= f.text_area :description, autofocus: true, placeholder: "グループの説明",
-                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500 dark:border-gray-600 dark:focus:ring-gray-900 dark:focus:border-gray-500" %>
+                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6 flex">
               <%= f.submit "作成",class: "mx-auto w-20 sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-center text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -6,12 +6,12 @@
             <div class="mb-6">
               <%= f.label :name, class: "block mb-2 text-base font-bold text-gray-500" %>
               <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "らんてっくぐるーぷ",
-                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
+                class: "w-full px-3 py-2 bg-gray-50 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6">
               <%= f.label :description, class: "block mb-2 text-base font-bold text-gray-500" %>
               <%= f.text_area :description, autofocus: true, placeholder: "グループの説明",
-                class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
+                class: "w-full px-3 py-2  bg-gray-50 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6 flex">
               <%= f.submit "作成",class: "mx-auto w-20 sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-center text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,12 +4,12 @@
 
             <%= form_with model: group, url: form_url, local: true do |f| %>
             <div class="mb-6">
-              <%= f.label :name, class: "block mb-2 text-sm text-gray-800" %>
+              <%= f.label :name, class: "block mb-2 text-sm text-gray-500" %>
               <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "らんてっくぐるーぷ",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6">
-              <%= f.label :description, class: "block mb-2 text-sm text-gray-800" %>
+              <%= f.label :description, class: "block mb-2 text-sm text-gray-500" %>
               <%= f.text_area :description, autofocus: true, placeholder: "グループの説明",
                 class: "w-full px-3 py-2 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -18,11 +18,11 @@
       <div class="flex flex-col items-center justify-center m-5 w-full sm:max-w-md mx-auto">
         <%= f.label :name, class: "font-bold mb-2" %>
         <%= f.text_field :name, autofocus: true, autocomplete: "name",
-                class: "w-full px-3 py-2 mb-4 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
+                class: "w-full px-3 py-2 mb-4 bg-gray-50 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
 
         <%= f.label :description, class: "font-bold mb-2" %>
         <%= f.text_area :description, autofocus: true, autocomplete: "description",
-                class: "w-full px-3 py-2 mb-5 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 " %>
+                class: "w-full px-3 py-2 mb-5 bg-gray-50 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 " %>
       </div>
       <div class="flex justify-center">
         <%= f.submit "更新", class: "w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-center text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none"%>

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -1,15 +1,11 @@
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
-    <!-- text - start -->
     <div class="my-10">
       <h2 class="text-center text-3xl font-bold text-gray-800"><%= t("groups.requests.edit") %></h2>
     </div>
-    <!-- text - end -->
 
-    <!-- フォームスタート -->
     <%= form_with model: @request, url: group_request_path, local: true do |f| %>
       <%= render partial: "requests/shared/form", locals: { group: @group, f: f } %>
     <% end %>
   </div>
 </div>
-      <!-- フォーム終わり -->

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,15 +1,11 @@
 <div class="bg-white my-5">
   <div class="mx-auto max-w-screen-2xl px-4">
-    <!-- text - start -->
     <div class="mt-10">
       <div class="text-center text-2xl sm:text-3xl font-bold text-gray-800"><%= t("groups.requests.new")%></div>
     </div>
-    <!-- text - end -->
 
-    <!-- フォームスタート -->
     <%= form_with model: @request, url: group_requests_path, local: true do |f| %>
       <%= render partial: "requests/shared/form", locals: { group: @group, f: f } %>
     <% end %>
   </div>
 </div>
-      <!-- フォーム終わり -->

--- a/app/views/requests/shared/_form.html.erb
+++ b/app/views/requests/shared/_form.html.erb
@@ -4,18 +4,18 @@
   </div>
   <div class="col-span-2">
     <%= f.label :take, class: "mb-2 inline-block font-bold" %>
-    <%= f.text_field :take, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300", placeholder: "例：麻雀がしたい🀄️" %>
+    <%= f.text_field :take, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300", placeholder: "例：麻雀がしたい🀄️" %>
   </div>
   <div class="col-span-2">
     <%= f.label :execution_date, class: "mb-2 inline-block font-bold" %>
-    <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300" %>
+    <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
   </div>
   
   <div data-controller="image-preview" data-image-preview-width="200" class="col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
     <!-- 左側: 画像アップロードフィールド -->
     <div>
       <%= f.label :image, class: "mb-2 inline-block font-bold" %>
-      <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
+      <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 transition" %>
     </div>
     <!-- 右側: 画像プレビュー表示 -->
     <div data-image-preview-target="preview" class="col-span-1"></div>
@@ -26,11 +26,11 @@
   <%= f.fields_for :gives do |give_f| %>
     <div class="col-span-2 sm:col-span-1">
       <%= give_f.label :content, class: "mb-2 inline-block font-bold" %>
-      <%= give_f.text_field :content, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：風呂掃除" %>
+      <%= give_f.text_field :content, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 transition", placeholder: "例：風呂掃除" %>
     </div>
     <div class="col-span-2 sm:col-span-1">
       <%= give_f.label :deadline, class: "mb-2 inline-block font-bold" %>
-      <%= give_f.datetime_field :deadline, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
+      <%= give_f.datetime_field :deadline, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 transition" %>
     </div>
   <%end%>
 
@@ -38,11 +38,11 @@
 
   <div class="col-span-2">
     <%= f.label :comment, class: "mb-2 inline-block font-bold" %>
-    <%= f.text_area :comment, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：バスマジックリンも買ってきます！" %>
+    <%= f.text_area :comment, class: "w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 transition", placeholder: "例：バスマジックリンも買ってきます！" %>
   </div>
   <div class="col-span-2">
     <%= f.label :authorizers, class: "mb-2 inline-block font-bold" %>
-      <div class="w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition">
+      <div class="w-full rounded border bg-gray-50 px-3 py-2 focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300 transition">
         <%= collection_check_boxes(:request, :authorizer_ids, group.users.reject { |user| user == current_user }, :id, proc{ |user| user.profile.name }) do |a|%>
           <%= a.label {a.check_box + a.text}%>
         <% end %>

--- a/app/views/requests/shared/_form.html.erb
+++ b/app/views/requests/shared/_form.html.erb
@@ -3,18 +3,18 @@
     <%= f.hidden_field :group_id, value: params[:group_id] %>
   </div>
   <div class="col-span-2">
-    <%= f.label :take, class: "mb-2 inline-block" %>
+    <%= f.label :take, class: "mb-2 inline-block font-bold" %>
     <%= f.text_field :take, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300", placeholder: "例：麻雀がしたい🀄️" %>
   </div>
   <div class="col-span-2">
-    <%= f.label :execution_date, class: "mb-2 inline-block" %>
+    <%= f.label :execution_date, class: "mb-2 inline-block font-bold" %>
     <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300" %>
   </div>
   
   <div data-controller="image-preview" data-image-preview-width="200" class="col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
     <!-- 左側: 画像アップロードフィールド -->
     <div>
-      <%= f.label :image, class: "mb-2 inline-block" %>
+      <%= f.label :image, class: "mb-2 inline-block font-bold" %>
       <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
     </div>
     <!-- 右側: 画像プレビュー表示 -->
@@ -25,11 +25,11 @@
 
   <%= f.fields_for :gives do |give_f| %>
     <div class="col-span-2 sm:col-span-1">
-      <%= give_f.label :content, class: "mb-2 inline-block" %>
+      <%= give_f.label :content, class: "mb-2 inline-block font-bold" %>
       <%= give_f.text_field :content, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：風呂掃除" %>
     </div>
     <div class="col-span-2 sm:col-span-1">
-      <%= give_f.label :deadline, class: "mb-2 inline-block" %>
+      <%= give_f.label :deadline, class: "mb-2 inline-block font-bold" %>
       <%= give_f.datetime_field :deadline, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
     </div>
   <%end%>
@@ -37,11 +37,11 @@
   <div class="col-span-2 border-b-2"></div>
 
   <div class="col-span-2">
-    <%= f.label :comment, class: "mb-2 inline-block" %>
+    <%= f.label :comment, class: "mb-2 inline-block font-bold" %>
     <%= f.text_area :comment, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：バスマジックリンも買ってきます！" %>
   </div>
   <div class="col-span-2">
-    <%= f.label :authorizers, class: "mb-2 inline-block" %>
+    <%= f.label :authorizers, class: "mb-2 inline-block font-bold" %>
       <div class="w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition">
         <%= collection_check_boxes(:request, :authorizer_ids, group.users.reject { |user| user == current_user }, :id, proc{ |user| user.profile.name }) do |a|%>
           <%= a.label {a.check_box + a.text}%>

--- a/app/views/requests/shared/_form.html.erb
+++ b/app/views/requests/shared/_form.html.erb
@@ -1,21 +1,21 @@
-<div class="mx-auto grid gap-4 grid-cols-1 sm:grid-cols-2 max-w-screen-md text-xs sm:text-base">
+<div class="mx-auto grid gap-4 grid-cols-1 sm:grid-cols-2 max-w-screen-md text-xs sm:text-base text-gray-500">
   <div class="col-span-2">
     <%= f.hidden_field :group_id, value: params[:group_id] %>
   </div>
   <div class="col-span-2">
-    <%= f.label :take, class: "mb-2 inline-block text-gray-800" %>
-    <%= f.text_field :take, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300", placeholder: "例：麻雀がしたい🀄️" %>
+    <%= f.label :take, class: "mb-2 inline-block" %>
+    <%= f.text_field :take, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300", placeholder: "例：麻雀がしたい🀄️" %>
   </div>
   <div class="col-span-2">
-    <%= f.label :execution_date, class: "mb-2 inline-block text-gray-800" %>
-    <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300" %>
+    <%= f.label :execution_date, class: "mb-2 inline-block" %>
+    <%= f.datetime_field :execution_date, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300" %>
   </div>
   
   <div data-controller="image-preview" data-image-preview-width="200" class="col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
     <!-- 左側: 画像アップロードフィールド -->
     <div>
-      <%= f.label :image, class: "mb-2 inline-block text-gray-800" %>
-      <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition" %>
+      <%= f.label :image, class: "mb-2 inline-block" %>
+      <%= f.file_field :image, data: {"image-preview-target": "input", "action": "change->image-preview#previewImage"}, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
     </div>
     <!-- 右側: 画像プレビュー表示 -->
     <div data-image-preview-target="preview" class="col-span-1"></div>
@@ -25,24 +25,24 @@
 
   <%= f.fields_for :gives do |give_f| %>
     <div class="col-span-2 sm:col-span-1">
-      <%= give_f.label :content, class: "mb-2 inline-block text-gray-800" %>
-      <%= give_f.text_field :content, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition", placeholder: "例：風呂掃除" %>
+      <%= give_f.label :content, class: "mb-2 inline-block" %>
+      <%= give_f.text_field :content, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：風呂掃除" %>
     </div>
     <div class="col-span-2 sm:col-span-1">
-      <%= give_f.label :deadline, class: "mb-2 inline-block text-gray-800" %>
-      <%= give_f.datetime_field :deadline, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition" %>
+      <%= give_f.label :deadline, class: "mb-2 inline-block" %>
+      <%= give_f.datetime_field :deadline, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition" %>
     </div>
   <%end%>
 
   <div class="col-span-2 border-b-2"></div>
 
   <div class="col-span-2">
-    <%= f.label :comment, class: "mb-2 inline-block text-gray-800" %>
-    <%= f.text_area :comment, class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition", placeholder: "例：バスマジックリンも買ってきます！" %>
+    <%= f.label :comment, class: "mb-2 inline-block" %>
+    <%= f.text_area :comment, class: "w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition", placeholder: "例：バスマジックリンも買ってきます！" %>
   </div>
   <div class="col-span-2">
-    <%= f.label :authorizers, class: "mb-2 inline-block text-gray-800" %>
-      <div class="w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition">
+    <%= f.label :authorizers, class: "mb-2 inline-block" %>
+      <div class="w-full rounded border bg-gray-50 px-3 py-2 outline-none ring-indigo-300 transition">
         <%= collection_check_boxes(:request, :authorizer_ids, group.users.reject { |user| user == current_user }, :id, proc{ |user| user.profile.name }) do |a|%>
           <%= a.label {a.check_box + a.text}%>
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
           <%= link_to "所属グループ一覧", groups_path, class: "px-6 py-6 text-sm border-b-2 border-transparent leading-[22px] #{ header_group_index_class } hover:text-blue-500" %>
         </li>
         <li>
-          <%= link_to "使い方", root_path, class: "px-6 py-6 text-sm border-b-2 border-transparent leading-[22px] #{ header_group_index_class } hover:text-blue-500" %>
+          <%= link_to "使い方", root_path, class: "px-6 py-6 text-sm border-b-2 border-transparent leading-[22px] #{ header_top_class } hover:text-blue-500" %>
         </li>
         <li>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: {controller: "logout" }, class: "px-2 sm:px-6 py-0 sm:py-2 text-xs sm:text-sm border-b-2 border-transparent leading-[22px] text-gray-500 hover:text-blue-500" %>


### PR DESCRIPTION
テキストカラーを`text-gray-500`に統一
ef24756d93f480426ee4a45eb702512d30a3444f
f3d395eae79230ca4ab25760762eb78c28236170
ef24756d93f480426ee4a45eb702512d30a3444f

フォームの背景色を`bg-gray-50`に統一
62ae54febad3484eef1e448dba5317406d51984e
4714ad5d16e5b0362ea19160fcfa41d6c8994f91

フォームラベルと`font-bold`に統一
5139665595f349a510502c00e02152ca0f0e2757
9758f5d5a3225e2b3703d0771d6a9f5cbca684f7

フォームを選択したときにフォーム周りに`focus:ring-indigo-100 focus:border-indigo-300`が適用されるように統一
92038fe9fd75c9e975a611e6cd329d86c0c70c8c

`application_helper.rb`にヘルパーメソッドを追加
```ruby
  def header_top_class
    if params[:controller] == 'top_page' && params[:action] == 'top'
      'text-blue-500'
    else
      'text-gray-500'
    end
  end
```
これをヘッダー「使い方」に適用させアクティブ化の実装
c39c53c7cecd8f4f2b125f4b97448d4c6fe16a5d