### PR TITLE
ログアウト時のフラッシュ背景色をalertに変更

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,2 +1,7 @@
 class Users::SessionsController < Devise::SessionsController
+  def destroy
+    super
+    flash.delete(:notice)
+    flash[:alert] = 'ログアウトしました'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
   get 'privacy', to: 'top_page#privacy'
 
   devise_for :users, controllers: {
-    omniauth_callbacks: 'omniauth_callbacks'
+    omniauth_callbacks: 'omniauth_callbacks',
+    sessions: 'users/sessions'
   }
   resource :profile, only: %i[show edit update] do
     get 'personal_requests', to: 'profiles#personal_requests'


### PR DESCRIPTION
ログアウトのフラッシュシンボルがデフォルトで`:notice`のためdeviseのsesseions_controller.rbをオーバーライドし、一度    `flash.delete(:notice)`でフラッシュの削除を行い`flash[:alert] = 'ログアウトしました'`を追加した