### PR TITLE
招待されたユーザーが未ログインの場合のページ遷移先をroot_pathに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 
@@ -50,5 +51,9 @@ class ApplicationController < ActionController::Base
     end
 
     super
+  end
+
+  def authenticate_user!
+    root_path unless user_signed_in?
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -20,7 +20,7 @@ class InvitesController < ApplicationController
 
       redirect_to root_path, notice: "#{@group.name}グループに追加されました"
     else
-      redirect_to user_session_path
+      redirect_to root_path
     end
   end
 end


### PR DESCRIPTION
未ログインユーザーが招待リンクを受け取ってアクセスした時のページ遷移先が`user_sessions_path`だったため`root_path`に修正（LINEログインで会員登録を行うため）