### PR TITLE
RSpecによるテストを行うための設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
-  gem 'spring-commands-rspec'
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile
+++ b/Gemfile
@@ -73,16 +73,16 @@ gem 'meta-tags'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
   gem 'rspec-rails'
   gem 'factory_bot_rails'
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'rubocop', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec', require: false
   gem 'web-console'
   gem 'spring-commands-rspec'
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]

--- a/Gemfile
+++ b/Gemfile
@@ -96,4 +96,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdriver (0.19.0)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -449,6 +450,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdriver
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,9 +364,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    spring (4.1.3)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -444,7 +441,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
-  spring-commands-rspec
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactorBot::Syntax::Methods
+  config.before(:each, type: :system) do
+    driven_by(:selenium_chrome_headless)
+    # driven_by(:selenium_chrome)
+    # driven_by(:rack_test)
+  end
 end


### PR DESCRIPTION
`rails_helper.rb`に下記内容を追加して、テスト時のドライバを選択できるように修正
```ruby
  config.before(:each, type: :system) do
    driven_by(:selenium_chrome_headless)
    # driven_by(:selenium_chrome)
    # driven_by(:rack_test)
```
bb8741ba6666e7b9aeccc02fddc29beec65c9f83

前回のPR( #214 )で`spring-commands-rspec`を利用できるように設定したが、PC本体が熱を持ってしまい処理が遅くなるため削除した
4cc09ccac43cd6567c478e2af969f3a7b35de1a2