### PR TITLE
プロフィール編集ページのテスト

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.filter_run_when_matching :focus
   config.before(:each, type: :system) do
     driven_by(:selenium_chrome_headless)
     # driven_by(:selenium_chrome)

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Profile", type: :system do
       click_on 'LINEアカウントでログイン'
       visit profile_path
     end
-    context 'プロフィール詳細画面が表示されている場合' do
+    context 'プロフィール詳細' do
       it 'プロフィール名が表示されている' do
         expect(page).to have_content 'test_user'
       end
@@ -19,6 +19,23 @@ RSpec.describe "Profile", type: :system do
       it '個人リクエスト一覧ボタンを押すと個人リクエスト一覧画面に遷移する' do
         click_on '個人リクエスト一覧'
         expect(page).to have_current_path(personal_requests_profile_path)
+      end
+    end
+    context 'プロフィール編集' do
+      before do
+        visit edit_profile_path
+      end
+      fit 'フォームが正しく表示されている' do
+        expect(page).to have_field('名前', with: 'test_user')
+        expect(page).to have_field('自己紹介')
+      end
+      fit 'フォームの内容を変更して更新することができる' do
+        fill_in '名前', with: 'test_user_2'
+        fill_in '自己紹介', with: '自己紹介テスト'
+        click_on '更新'
+        expect(page).to have_current_path(profile_path)
+        expect(page).to have_content 'test_user_2'
+        expect(page).to have_content '自己紹介テスト'
       end
     end
   end


### PR DESCRIPTION
特定テストを処理できるように`rails_helper`に設定追加
`config.filter_run_when_matching :focus`
0d59ab4e34dff134ad332029d8517597841691a5

プロフィール編集テスト追加
・フォームが正しく表示されているか
・更新が正しく実行されるかどうか