### PR TITLE
グループテストの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     line-bot-api (1.28.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -429,6 +431,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  launchy
   line-bot-api
   meta-tags
   mimemagic

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -14,7 +14,7 @@
                 class: "w-full px-3 py-2  bg-gray-50 placeholder-gray-300 border border-gray-300 rounded-md focus:outline-none focus:ring focus:ring-indigo-100 focus:border-indigo-300" %>
             </div>
             <div class="mb-6 flex">
-              <%= f.submit "作成",class: "mx-auto w-20 sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-center text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>
+              <%= f.submit group.new_record? ? "作成" : "更新",class: "mx-auto w-20 sm:w-36 px-2 sm:px-3 py-2 sm:py-4 text-sm sm:text-base text-center text-white bg-indigo-500 rounded-md focus:bg-indigo-600 focus:outline-none" %>
             </div>
             <% end %>
         </div>

--- a/spec/factories/group_users.rb
+++ b/spec/factories/group_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :group_user do
+    association :user
+    association :group
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :group do
+    name { Faker::Team.name }
+    description { Faker::Lorem.sentence }
+    association :owner, factory: :user
+
+    after(:create) do |group|
+      create(:group_user, group: group, user: group.owner)
+    end
+  end
+end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,5 +1,5 @@
 module AuthHelpers
-  def user_sign_in_via_line
+  def user_sign_in_via_line(user)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:line] = OmniAuth::AuthHash.new(
       provider: 'line',

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Group", type: :system do
+  describe 'グループ' do
+    let!(:user) { create(:user) }
+    before do
+      Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:line]
+      user_sign_in_via_line(user)
+      visit root_path
+      click_on 'LINEアカウントでログイン'
+    end
+    context 'グループ新規作成' do
+      it '新規作成に成功する' do
+        visit new_group_path
+        fill_in "グループネーム", with: "テストグループ"
+        click_on '作成'
+        expect(page).to have_current_path(groups_path)
+        expect(page).to have_content('テストグループ')
+      end
+    end
+    context 'グループ編集' do
+      let!(:group) { create(:group, owner: user) }
+      it 'グループ詳細画面遷移に成功する' do
+        visit group_path(group)
+        expect(page).to have_current_path(group_path(group))
+      end
+      it 'グループ情報の編集に成功する' do
+        visit edit_group_path(group)
+        fill_in 'グループネーム', with: 'テストグループ更新'
+        fill_in '説明', with: '説明テスト'
+        click_on '更新'
+        expect(page).to have_content('テストグループ更新')
+      end
+      fit 'グループの削除に成功する' do
+        visit group_path(group)
+        find_button('削除').click
+        expect(page).not_to have_content(group.name)
+        expect(page).to have_current_path(groups_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
groupの`_form.html.erb`のボタン部分が常に`作成`になっていたため
group.new_record? ? "作成" : "更新"
とし変化するようにした
e9d71461a1e6f304a52373cb6da0d30afcf46f21

RSpecを用いてテストを記述している時`save_and_open_page`で自動的にHTMLを開くようgem `launchy`を導入
b9762a83e47e1d4ea3e5fbb2bbc400d0ae543c4e

ログインしたユーザーでログイン画面に遷移するために`user_sign_in_via_line`に引数(user)を追加
b10b18f49999ae334f70eec955edd96becca7a80

グループ作成時、`group_users`中間テーブルに作成したgroupとuserが追加されるようにグループファクトリを作成
ca3c3a28c9b33f2936fbdd0805f8fba54071de2c
68cbbcdc2945c671b573b3fad06c5363e4d7a2c7


グループテストを追加
・グループの新規作成
・グループ情報の編集
・グループの削除
83b331dae4e19f21cf6787b7328ec98bd1854c3c
