### PR TITLE
タブのアクティブ化

### DIFF
--- a/app/javascript/controllers/tab_controller.js
+++ b/app/javascript/controllers/tab_controller.js
@@ -19,8 +19,14 @@ export default class extends Controller {
   switchTab(event) {
     event.preventDefault();
 
-    this.tabTargets.forEach(tab => tab.classList.remove("active"));
+    this.tabTargets.forEach(tab =>  {
+      tab.classList.remove("active");
+      tab.querySelector('div').classList.remove('text-blue-600');
+      tab.querySelector('div').classList.remove('border-blue-500')
+    });
     event.currentTarget.classList.add("active");
+    event.currentTarget.querySelector('div').classList.add('text-blue-600');
+    event.currentTarget.querySelector('div').classList.add('border-blue-500');
 
     this.updateTabsAndPanels();
   }

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -8,14 +8,14 @@
 
       <div class="text-sm font-medium text-center text-gray-500 border-b border-gray-200 mb-5">
         <ul class="flex flex-wrap justify-center -mb-px">
-            <li class="mx-10" data-tab-target="tab" class="active" data-tab-status-value="unauthorized" data-action="click->tab#switchTab">
-                <div class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300">未承認</div>
+            <li class="sm:mx-10 mx-2 active" data-tab-target="tab" data-tab-status-value="unauthorized" data-action="click->tab#switchTab">
+                <div class="inline-block sm:p-2 border-b-2 border-blue-500 border-transparent rounded-t-lg text-blue-600 hover:text-blue-600 hover:border-blue-500 hover:cursor-pointer">未承認</div>
             </li>
-            <li class="mr-4" data-tab-target="tab" class="" data-tab-status-value="authorized" data-action="click->tab#switchTab">
-                <div class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300">承認済</div>
+            <li class="sm:mr-4 mx-2" data-tab-target="tab" data-tab-status-value="authorized" data-action="click->tab#switchTab">
+                <div class="inline-block sm:p-2 border-b-2 border-transparent rounded-t-lg hover:text-blue-600 hover:border-blue-500 hover:cursor-pointer">承認済</div>
             </li>
-            <li class="" data-tab-target="tab" class="" data-tab-status-value="possible" data-action="click->tab#switchTab">
-                <div class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300">タスク実行可能</div>
+            <li class="mx-2" data-tab-target="tab" data-tab-status-value="possible" data-action="click->tab#switchTab">
+                <div class="inline-block sm:p-2 border-b-2 border-transparent rounded-t-lg hover:text-blue-600 hover:border-blue-500 hover:cursor-pointer">タスク実行可能</div>
             </li>
         </ul>
       </div>
@@ -25,6 +25,7 @@
         <div data-tab-target="panel" status="authorized" class="hidden flex h-96"><%= render "/requests/shared/requests_list", title: t("groups.requests.index.authorized"), requests: @authorized_requests, paginate_param: "authorized_page" %></div>
         <div data-tab-target="panel" status="possible" class="hidden flex h-96"><%= render "/requests/shared/requests_list", title: t("groups.requests.index.possible"), requests: @possible_requests, paginate_param: "possile_page" %></div>
       </div>
+
     </div>
 
     <div class="flex justify-center items-end mt-12 gap-4 font-semibold hover:text-neutral-600">

--- a/app/views/requests/shared/_requests_list.html.erb
+++ b/app/views/requests/shared/_requests_list.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col overflow-hidden rounded-lg border-2 border-indigo-500 w-52">
+<div class="flex flex-col overflow-hidden rounded-lg border-2 border-indigo-500 w-52 sm:w-96">
   <div class="bg-indigo-500 py-2 text-center text-sm font-semibold uppercase tracking-widest text-white">
     <%= title %>
   </div>


### PR DESCRIPTION
switchTab発火時、選択した要素に`text-blue-600`,`border-blue-500`が付与されるように調整
e0e15cd420696f9758fbd954eabae09a266066c8

request_listのサイズを調整
モバイルサイズ時はそのまま
639745097b7ba21d510141f133536ab40686c7bb

カーソルがホバーしたとき
・カーソル種類の変化
・ホバーしている要素に`text-blue-600`,`border-blue-500`を追加
fd50d70191ed5cc3aef380e0423a0d2441a2c23d