### PR TITLE
docker化したアプリでRSpecのsystem specが走るよう修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get install -y nodejs && \
   npm install -g yarn
 
+RUN apt-get update -qq && apt-get install -y --no-install-recommends libvips42
+
 WORKDIR /app
 
 COPY Gemfile /app/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -97,5 +97,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'selenium-webdriver'
-  # gem 'webdriver', require: !ENV['SELENIUM_DRIVER_URL']
+  # gem 'webdriver'
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       bash -c "rm -f /app/tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
+      - ./tmp:/app/tmp # RSpec画像でデバッグできるように
     ports:
       - "3000:3000"
     depends_on:
@@ -28,8 +29,13 @@ services:
       DB_PASSWORD: postgres
       SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
 
+
   selenium_chrome:
     image: seleniarm/standalone-chromium
+    shm_size: 256m #メモリ不足を解消
+    environment:
+      - SE_NODE_MAX_SESSIONS=2 #デフォルトでは有効なセッション数は1つのみ　２つに拡張
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
     ports:
       - 4444:4444
 

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,11 +1,10 @@
 FactoryBot.define do
   factory :profile do
-    name { Faker::Internet.username}
+    name { Faker::Internet.username }
     role { 0 }
-    association:user
+    association :user
 
     after(:build) do |profile|
-
       profile.avatar.attach(
         io: File.open(Rails.root.join('spec', 'fixtures', 'test.png')),
         filename: 'test.png',

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,12 +16,15 @@ end
 
 # Chrome
 Capybara.register_driver :remote_chrome do |app|
-  url = 'http://selenium_chrome:4444/wd/hub'
+  url = ENV['SELENIUM_DRIVER_URL']
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.add_argument('no-sandbox')
   options.add_argument('headless')
   options.add_argument('disable-gpu')
   options.add_argument('window-size=1680,1050')
 
-  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, options: options)
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120
+
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, options: options, http_client: client)
 end

--- a/spec/system/message_spec.rb
+++ b/spec/system/message_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe 'Message', type: :system do
       end
     end
 
+    after do
+      Capybara.reset_sessions! # セッションを状態をリセット
+    end
+
     context 'チャット送信' do
       it '既存チャットメッセージの表示が成功している' do
         fill_in 'chat_text', with: 'テストチャット'

--- a/spec/system/request_spec.rb
+++ b/spec/system/request_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "Request", type: :system do
         visit group_requests_path(group)
         click_on '新規リクエスト作成'
         fill_in 'request_take', with: 'テストリクエスト'
-        fill_in 'request_execution_date', with: '2024-02-22T00:00'
+        script = "document.getElementById('request_execution_date').value = '2024-02-22T00:00:00'"
+        page.execute_script(script)
         fill_in 'request_gives_attributes_0_content', with: 'テストギブ0'
         fill_in 'request_gives_attributes_1_content', with: 'テストギブ1'
         fill_in 'request_gives_attributes_2_content', with: 'テストギブ2'


### PR DESCRIPTION
docker環境に`vips`をインストール
8f971b5340be4f2cbfd276ca17330f2c3d843977

日時を入力するフォームに正確に入力することができなかったためjsを用いた入力方法に修正
bbece7642b58850fa2003d424d321959c311ed87

`using_session`を使うにあたってコンテナのセッション上限数をデフォルトの1から2に修正
b31a88434c252f76aa407b4844a952f140814cb8

`capybara`のタイムアウト上限をデフォルトの60秒から120秒に拡張
`docker-compose.yml`から取得した環境変数`SELENIUM_DRIVER_URL`をurlに代入
05ce2f5d38f90b74c7d82d62cefcce462707d5c3

テストごとにセッション情報をクリアにするために
```ruby:message_spec.rb
after do
  Capybara.reset_sessions!
end
```
を追記
62f9537676794aa0a7d3083087808c30c64ed1c0
