### PR TITLE
gem shoulda-matchersの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,4 +99,5 @@ group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
   # gem 'webdriver'
+  gem "shoulda-matchers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -452,6 +454,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
+  shoulda-matchers
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,3 +26,10 @@ RSpec.configure do |config|
   #end
   config.include AuthHelpers, type: :system
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
model specのアソシエーションのテストを用意するために`shoulda-matchers`をGemに追加
`spec/rails_helper.rb`に公式wikiに記述されている内容を追加

https://github.com/thoughtbot/shoulda-matchers