### PR TITLE
Requestモデルのmodel specを追加

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -11,7 +11,7 @@ class Request < ApplicationRecord
   has_many :request_users, dependent: :destroy
   has_many :authorizers, through: :request_users, source: :user
   has_many :gives, class_name: 'Give', dependent: :destroy
-  accepts_nested_attributes_for :gives, allow_destroy: true, reject_if: :all_blank, limit: 3
+  accepts_nested_attributes_for :gives, allow_destroy: true, limit: 3
   has_many :messages, dependent: :destroy
 
   def image_thumbnail

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -102,5 +102,40 @@ RSpec.describe Request, type: :model do
         expect(request).not_to be_valid
       end
     end
+
+    context 'クラスメソッドのテスト' do
+      it 'imageがattachされていないrequestにimage_thumbnailメソッドを実行するとnilになるか' do
+        expect(valid_request.image_thumbnail).to be_nil
+      end
+
+      it 'imageが添付されている場合、image_thumbnailメソッドが正常に動作するか' do
+        valid_request.image.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', 'test.png')),
+          filename: 'test.png',
+          content_type: 'image/png'
+        )
+        expect(valid_request.image_thumbnail).to be_a(ActiveStorage::VariantWithRecord)
+      end
+
+      it 'authorizers_checkメソッドがが正常に動作しているか' do
+        user = create(:user)
+        other_user = create(:user)
+        request_user = create(:request_user, user: user, request: valid_request)
+
+        expect(valid_request.authorizers_check(user)).to be_truthy
+        expect(valid_request.authorizers_check(other_user)).to be_falsey
+      end
+
+      it 'own?メソッドが正常に動作しているか' do
+        user = create(:user)
+        other_user = create(:user)
+        request = create(:request, user: user)
+
+        expect(request.own?(user)).to be_truthy
+        expect(request.own?(other_user)).to be_falsey
+      end
+    end
   end
+
+
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe Request, type: :model do
+  describe 'Requestモデルのテスト' do
+    let(:valid_request) { create(:request) }
+
+    it '有効なrequestの場合、保存されるか' do
+      expect(valid_request).to be_valid
+    end
+
+    context 'Requestモデルのバリデーションのテスト' do
+      it 'takeが空白の場合、エラーを起こすか' do
+        request = build(:request, take: " ")
+        expect(request).not_to be_valid
+      end
+
+      it 'takeがnilの場合、エラーを起こすか' do
+        request = build(:request, take: nil)
+        expect(request).not_to be_valid
+      end
+
+      it '画像のコンテンツタイプ正しくない場合、エラーを起こすか' do
+        request = build(:request)
+        request.image.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', 'test.txt')),
+          filename: 'test.txt',
+          content_type: 'text/plain'
+        )
+        expect(request).not_to be_valid
+      end
+
+      it 'imageの画像ファイルサイズが重たすぎる場合、エラーを返すか' do
+        request = build(:request)
+        request.image.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', '10MB.jpeg')),
+          filename: '10MB.jpeg',
+          content_type: 'image/jpeg'
+        )
+        expect(request).not_to be_valid
+      end
+    end
+
+    context 'アソシエーションのテスト' do
+      it { should belong_to(:user) }
+      it { should belong_to(:group) }
+      it { should have_many(:request_users).dependent(:destroy) }
+      it { should have_many(:authorizers).through(:request_users).source(:user) }
+      it { should have_many(:gives).class_name('Give').dependent(:destroy) }
+      it { should have_many(:messages).dependent(:destroy) }
+    end
+
+    context 'accept_nested_attributes_forのテスト' do
+      it 'requestにネストされたgivesが2つもしくは3つの場合正常' do
+        request = build(:request)
+        expect {
+          request.attributes = {
+            gives_attributes: [
+              { content: "Give 1" },
+              { content: "Give 2"}
+            ]
+          }
+        }.not_to raise_error
+
+        expect {
+          request.attributes = {
+            gives_attributes: [
+              { content: "Give 1" },
+              { content: "Give 2" },
+              { content: "Give 3" }
+            ]
+          }
+        }.not_to raise_error
+      end
+
+      it 'requestにネストされたgivesが3つ以上ある場合エラーを起こす' do
+        request = build(:request)
+        expect {
+          request.attributes = {
+            gives_attributes: [
+              { content: "Give 1" },
+              { content: "Give 2" },
+              { content: "Give 3" },
+              { content: "Give 4" }
+            ]
+          }
+        }.to raise_error(ActiveRecord::NestedAttributes::TooManyRecords)
+      end
+    end
+
+    context 'enumの値のテスト' do
+      it 'statusの値が正しいこと' do
+        should define_enum_for(:status).with_values(unauthorized: 0, authorized: 1, possible: 2, completed: 3)
+      end
+
+      it 'statusの値が空白の場合、エラーを起こすか' do
+        request = build(:request, status: " ")
+        expect(request).not_to be_valid
+      end
+
+      it 'statusの値がnilの場合、エラーを起こすか' do
+        request = build(:request, status: nil)
+        expect(request).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
41f96cfb755ff1495964246bb018be834864801d
733cbbad25e7dc1c31063488077847d2c83af0a5
Requestモデルのmodel specを追加

ee13bb6cf37d2e4d3302253d83d2fef2d9a4f285
model specを記述しているうちにRequestモデルのmodel specを追加`request`にネストされて生成している`give`の`reject_if: :all_blank`がいらないことに気づいたので削除。
たしかに全項目が空白である場合、登録はしないでほしいがデフォルト値とアソシエーションしている`request`があるので意味なし。
もしつかうとしたら`give.content = " " && nil`みたいなロジックを書いてあげたほうがいいのかも
